### PR TITLE
Update LUA_RESTY_OIDC_VER to version 1.7.1-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Cristian Chiru <cristian.chiru@revomatico.com>
 
 ENV PACKAGES="openssl-devel kernel-headers gcc git openssh" \
     KONG_OIDC_VER="1.1.0-0" \
-    LUA_RESTY_OIDC_VER="1.6.1-1" \
+    LUA_RESTY_OIDC_VER="1.7.1-1" \
     KHTHR_VER="0.14.1-0"
 
 RUN set -x \


### PR DESCRIPTION
Hello,

Thanks for the helpful repository.

Because of lua-resty-oidc 1.6.1-1 has a bug and  bad performance, so we had to build the docker image ourselves, if you can update your [docker hub images](https://hub.docker.com/r/revomatico/docker-kong-oidc) to the new version  `1.7.1-1` , that would be a great help? 

Thanks!