### PR TITLE
Caching for discovery, jwks, introspection and compat notes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ set_decode_base64 \$session_secret \${{X_SESSION_SECRET}};\n" "$TPL" \
  # Patch nginx_kong.lua to set dictionaries
     && sed -i -E '/^lua_shared_dict kong\s+.+$/i\ \n\
 variables_hash_max_size 2048;\n\
+lua_shared_dict discovery \${{X_OIDC_CACHE_DISCOVERY_SIZE}};\n\
+lua_shared_dict jwks \${{X_OIDC_CACHE_JWKS_SIZE}};\n\
+lua_shared_dict introspection \${{X_OIDC_CACHE_INTROSPECTION_SIZE}};\n\
 > if x_session_storage == "shm" then\n\
 lua_shared_dict \${{X_SESSION_SHM_STORE}} \${{X_SESSION_SHM_STORE_SIZE}};\n\
 > end\n\
@@ -123,6 +126,10 @@ x_session_shm_lock_timeout = '5'\n\
 x_session_shm_lock_step = '0.001'\n\
 x_session_shm_lock_ratio = '2'\n\
 x_session_shm_lock_max_step = '0.5'\n\
+\n\
+x_oidc_cache_discovery_size = 128k\n\
+x_oidc_cache_jwks_size = 128k\n\
+x_oidc_cache_introspection_size = 128k\n\
 \n\
 " "$TPL" \
 ## Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong/kong:2.2.1
+FROM kong:2.2.1-alpine
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@
 ## Release notes
 - XXXX-XX-XX [X.X.X-X]:
     - Added `lua_shared_dict` caching for discovery, jwks and introspection. Default cache size is 128k (small).
+    - Bumped kong-oidc version to X.X.X-X to implement PR [revomatico#2](https://github.com/revomatico/kong-oidc/pull/2)
+    - Compatibility note: Groups/credentials are now injected regardless of `disable_userinfo_header` param
+    - Compatibility note: Param `disable_userinfo_header` is now honored also for introspection
+    - Compatibility note: OIDC authenticated request now clears possible (anonymous) consumer identity and sets X-Credential-Identifier
 - 2021-01-06 [2.2.1-2]:
     - Removed `x_proxy_cache_storage_name` in favor of built-in `nginx_http_lua_shared_dict`. See: https://github.com/Kong/kong/issues/4643
     - Bump `kong-plugin-session` to 2.4.4

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@
 
 
 ## Release notes
+- XXXX-XX-XX [X.X.X-X]:
+    - Added `lua_shared_dict` caching for discovery, jwks and introspection. Default cache size is 128k (small).
 - 2021-01-06 [2.2.1-2]:
     - Removed `x_proxy_cache_storage_name` in favor of built-in `nginx_http_lua_shared_dict`. See: https://github.com/Kong/kong/issues/4643
     - Bump `kong-plugin-session` to 2.4.4


### PR DESCRIPTION
Hello! Related to https://github.com/revomatico/kong-oidc/pull/2, this pull request would:
* Add caching for jwks, discovery and introspection (per https://github.com/zmartzone/lua-resty-openidc)
* Provide few compatibility notes about kong-oidc changes. Version numbers are placeholders
* Change base image to point to images at https://hub.docker.com/_/kong that appears to be the kong-official source

The default cache sizes are set quite small. I would think jwks/discovery docs are in most deployments few and small, but introspection cache requirement could vary widely.

Please have look and let know! :) Thanks!