### PR TITLE
Add KONG_X_SESSION_COMPRESSOR to enable session compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ lua_shared_dict \${{X_SESSION_SHM_STORE}} \${{X_SESSION_SHM_STORE_SIZE}};\n\
     ## Session:
     set \$session_storage \${{X_SESSION_STORAGE}};\n\
     set \$session_name \${{X_SESSION_NAME}};\n\
+    set \$session_compressor \${{X_SESSION_COMPRESSOR}};\n\
     ## Session: Memcached specific
     set \$session_memcache_connect_timeout \${{X_SESSION_MEMCACHE_CONNECT_TIMEOUT}};\n\
     set \$session_memcache_send_timeout \${{X_SESSION_MEMCACHE_SEND_TIMEOUT}};\n\
@@ -93,6 +94,7 @@ lua_shared_dict \${{X_SESSION_SHM_STORE}} \${{X_SESSION_SHM_STORE_SIZE}};\n\
     && sed -i "/\]\]/i\ \n\
 x_session_storage = cookie\n\
 x_session_name = oidc_session\n\
+x_session_compressor = 'none'\n\
 x_session_secret = ''\n\
 \n\
 x_session_memcache_prefix = oidc_sessions\n\

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 - This is the default, but not recommended. I would recommend **shm** for a single instance, lightweight deployment.
 - If you have too much information in the session (claims, etc), you may need to [increase the nginx header size](https://github.com/bungle/lua-resty-session#cookie-storage-adapter):
     - `KONG_NGINX_LARGE_CLIENT_HEADER_BUFFERS='4 16k'`
+- You can also enable [session compression](https://github.com/bungle/lua-resty-session#pluggable-compressors) to reduce cookie size:
+    - `KONG_X_SESSION_COMPRESSOR=zlib`
 
 
 ## Session: Memcached
@@ -102,6 +104,8 @@
 
 
 ## Release notes
+- XXXX-XX-XX [X.X.X-X]:
+    - Added session compression configuration using `KONG_X_SESSION_COMPRESSOR`
 - 2021-01-16 [2.3.0-1]:
     - Bumped Kong to 2.3.0
 - 2021-01-16 [2.2.1-3]:


### PR DESCRIPTION
Hello! This proposed patch would make it possible to enable compression in `lua-resty-session`. If using cookie-based session storage, this can reduce the cookie size significantly if there are lot of claims or long claims.