### PR TITLE
Updated README; Bump kong-oidc to 1.2.3-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL authors="Rami Abusereya <rami.abusereya@revomatico.com>,Cristian Chiru <cr
 
 ENV PACKAGES="openssl-devel kernel-headers gcc git openssh" \
     LUA_BASE_DIR="/usr/local/share/lua/5.1" \
-    KONG_OIDC_VER="1.2.2-1" \
+    KONG_OIDC_VER="1.2.3-1" \
     LUA_RESTY_OIDC_VER="1.7.4-1" \
     KONG_PLUGIN_SESSION_VER="2.4.4" \
     NGX_DISTRIBUTED_SHM_VER="1.0.2"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@
 
 
 ## Release notes
+- 2021-02-17 [2.4.0-1]:
+    - Bumped kong-oidc version to 1.2.3-1 to implement PR [revomatico#3](https://github.com/revomatico/kong-oidc/pull/3) and [revomatico#4](https://github.com/revomatico/kong-oidc/pull/4)
 - 2021-01-21 [2.3.0-2]:
     - Added session compression configuration using `KONG_X_SESSION_COMPRESSOR`
 - 2021-01-16 [2.3.0-1]:

--- a/common.sh
+++ b/common.sh
@@ -2,4 +2,4 @@
 
 # Common script used by all others to define variables and stay DRY
 DOCKER_CONTAINER='docker-kong-oidc'
-DOCKER_IMAGE="local/$DOCKER_CONTAINER:2.3.0-2"
+DOCKER_IMAGE="local/$DOCKER_CONTAINER:2.4.0-1"


### PR DESCRIPTION
Blocked by https://github.com/revomatico/kong-oidc/pull/5