### PR TITLE
Remove 'setcap 'cap_net_bind_service=+ep'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,9 +139,5 @@ x_oidc_cache_introspection_size = 128k\n\
     && apk del .build-dependencies 2>/dev/null \
 ## Create kong and working directory (https://github.com/Kong/kong/issues/2690)
     && mkdir -p /usr/local/kong \
-    && chown -R kong:`id -gn kong` /usr/local/kong \
-    # Allow regular users to run these programs and bind to ports < 1024
-    && setcap 'cap_net_bind_service=+ep' /usr/local/bin/kong \
-    && setcap 'cap_net_bind_service=+ep' /usr/local/openresty/nginx/sbin/nginx
-
+    && chown -R kong:`id -gn kong` /usr/local/kong
 USER kong

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@
 
 
 ## Release notes
+- XXXX-XX-XX [X.X.X-X]:
+    - Do not add NET_BIND_SERVICE capability to make it easier to deploy the image in environments with security constraints
 - 2021-02-17 [2.3.2-1]:
     - Bumped kong to 2.3.2
 - 2021-02-17 [2.3.0-3]:


### PR DESCRIPTION
I would propose to remove the NET_BIND_SERVICE from executables. It would match the base image and make it easier to use this image as drop-in alternative for the standard kong image. And also play together better with PodSecurityPolicies that K8s clusters may have. 

What do you think? 

> _Recent kong images do not anymore bind to privileged port 80 by default. Thus for most deployment scenarios the NET_BIND_SERVICE capability is not required. Dropping the capability makes it easier to run image in environments that
restrict permitted capabilities for example using k8s PodSecurityPolicy._