### PR TITLE
Use kong release image as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong/kong:2.8.0
+FROM kong:2.8.0-alpine
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@
 
 ## Release notes
 
+- 2022-XX-XX [X.X.X-X]
+  - Use kong official release image as base image
 - 2022-03-03 [2.8.0-1]:
   - Bump kong to 2.8.0
 - 2022-02-15 [2.7.1-1]:


### PR DESCRIPTION
I would propose the following correction to the base image used and to continue in future to use the official image that becomes available bit after the code release.

Use kong:x.x.x-alpine (https://hub.docker.com/_/kong) as base image
instead of kong/kong:x.x.x (https://hub.docker.com/r/kong/kong/).

Per https://docs.konghq.com/gateway/2.8.x/install-and-run/docker/
and the docker hub information the former is the official release image,
while the latter is a nightly image (presumably a pre-release).

```
$ docker run --rm -it --entrypoint="" kong:2.8.0-alpine env | grep KONG_VER
KONG_VERSION=2.8.0
$ docker run --rm -it --entrypoint="" kong/kong:2.8.0 env | grep KONG_VER
KONG_VERSION=2.7.1
```